### PR TITLE
Allow building with CMake on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,22 +7,24 @@ set (CRYPTOLENS_CURL_EMBED_CACERTS OFF CACHE BOOL "embed the ca certs in the lib
 set (SRC "src/ActivateError.cpp" "src/DataObject.cpp" "src/LicenseKey.cpp" "src/LicenseKeyChecker.cpp" "src/LicenseKeyInformation.cpp" "src/MachineCodeComputer_static.cpp" "src/RawLicenseKey.cpp" "src/ResponseParser_ArduinoJson5.cpp" "src/basic_SKM.cpp" "src/cryptolens_internals.cpp" "third_party/base64_OpenBSD/base64.cpp")
 set (LIBS "pthread" "dl")
 
-find_package(OpenSSL)
-if (${OpenSSL_FOUND})
+if(NOT WIN32)
+  find_package(OpenSSL)
+  if (${OpenSSL_FOUND})
   set (SRC  ${SRC} "src/SignatureVerifier_OpenSSL.cpp")
   set (LIBS ${LIBS} crypto)
-endif ()
-
-find_package(CURL)
-if (${CURL_FOUND})
-  set (SRC ${SRC} "src/RequestHandler_curl.cpp")
-  set (LIBS ${LIBS} curl ssl crypto)
-
-  if ((${CRYPTOLENS_CURL_EMBED_CACERTS}) OR (${SKM_CURL_EMBED_CACERTS}))
-    add_definitions (-DCRYPTOLENS_CURL_EMBED_CACERTS)
-    set (SRC ${SRC} "src/RequestHandler_curl_cacerts.cpp")
   endif ()
-endif ()
+
+  find_package(CURL)
+  if (${CURL_FOUND})
+    set (SRC ${SRC} "src/RequestHandler_curl.cpp")
+    set (LIBS ${LIBS} curl ssl crypto)
+
+    if ((${CRYPTOLENS_CURL_EMBED_CACERTS}) OR (${SKM_CURL_EMBED_CACERTS}))
+      add_definitions (-DCRYPTOLENS_CURL_EMBED_CACERTS)
+      set (SRC ${SRC} "src/RequestHandler_curl_cacerts.cpp")
+    endif ()
+  endif ()
+endif()
 
 add_library (cryptolens STATIC ${SRC})
 target_link_libraries (cryptolens ${LIBS})


### PR DESCRIPTION
Hi all!

I'm currently evaluating your service and found that there isn't really much needed to get this built with CMake on Windows.
This way we are able to integrate it as a CMake subproject instead of adding a separate build step.

The change skips the CURL and OpenSSL parts for Windows (which causes problems when CURL or OpenSSL are actually found there).

Best,
Jonathan