### PR TITLE
Add windows specific source files and option for MachineCodeComputer_COM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,10 @@ set (CRYPTOLENS_BUILD_TESTS OFF CACHE BOOL "build tests?")
 set (CRYPTOLENS_CURL_EMBED_CACERTS OFF CACHE BOOL "embed the ca certs in the library instead of using system default files?")
 
 set (SRC "src/ActivateError.cpp" "src/DataObject.cpp" "src/LicenseKey.cpp" "src/LicenseKeyChecker.cpp" "src/LicenseKeyInformation.cpp" "src/MachineCodeComputer_static.cpp" "src/RawLicenseKey.cpp" "src/ResponseParser_ArduinoJson5.cpp" "src/basic_SKM.cpp" "src/cryptolens_internals.cpp" "third_party/base64_OpenBSD/base64.cpp")
-set (LIBS "pthread" "dl")
 
 if(NOT WIN32)
+  set (LIBS "pthread" "dl")
+
   find_package(OpenSSL)
   if (${OpenSSL_FOUND})
   set (SRC  ${SRC} "src/SignatureVerifier_OpenSSL.cpp")
@@ -24,7 +25,20 @@ if(NOT WIN32)
       set (SRC ${SRC} "src/RequestHandler_curl_cacerts.cpp")
     endif ()
   endif ()
+else()
+    add_definitions (-DUNICODE -D_UNICODE)
+
+    # Windows specific source files
+    list (APPEND SRC "src/RequestHandler_WinHTTP.cpp" "src/SignatureVerifier_CryptoAPI.cpp")
+    list (APPEND LIBS "winhttp")
+
+    set (CRYPTOLENS_BUILD_MACHINE_CODE_COM OFF CACHE BOOL "build with MachineCodeComputer_COM?")
+    if (CRYPTOLENS_BUILD_MACHINE_CODE_COM)
+        list (APPEND SRC "src/MachineCodeComputer_COM.cpp" "third_party/curl/isunreserved.cpp")
+        list (APPEND LIBS "Iphlpapi")
+    endif()
 endif()
+
 
 add_library (cryptolens STATIC ${SRC})
 target_link_libraries (cryptolens ${LIBS})


### PR DESCRIPTION
Hi @svedi , @artemlos !

In the last PR, #8, only CMake configure ran through, compiling and linking fails, though, since there actually are quite a few more differences.
Here are more (but overseeable) changes that "clutter" the CMakeLists.txt.

I am unsure, if you are fine with putting these into the build system that you had primarily meant as way to build on Unix.
This is the more consistent way to build cross-platform (i.e. generating Ninja or Visual Studio projects from the cmake on all platforms), hence I will keep this in my fork one way or another.
It does make the Visual Studio projects redundant, however. And that could lead to one or the other getting out of date / forgotten, generally annoying to maintain.

As I see how having the Visual Studio projects is more attractive for Windows-only customers that might not know CMake, I can't easily recommend removing them. Maybe, though, pre-generating the .sln and .cproj files through CMake is an option (and could be done via a Github workflow / bot to avoid it being forgotten).

Anyway, putting this out there, someone will find it useful.

Best,
Jonathan