### PR TITLE
Set call on make_license_key parse errors

### DIFF
--- a/include/cryptolens/basic_Cryptolens.hpp
+++ b/include/cryptolens/basic_Cryptolens.hpp
@@ -967,17 +967,30 @@ basic_Cryptolens<Configuration>::make_license_key(basic_Error & e, std::string c
     ::cryptolens_io::v20190401::internal::handle_activate(e, this->response_parser, this->signature_verifier, s);
 
   if (e) {
+    if (e.get_subsystem(api::main()) != errors::Subsystem::Json) {
+      e.set_call(api::main(), errors::Call::BASIC_SKM_MAKE_LICENSE_KEY);
+      return nullopt;
+    }
+
     e.reset(api::main());
 
     size_t k = s.find('-');
-    if (k == std::string::npos) { e.set(api::main(), errors::Subsystem::Main, errors::Main::UNKNOWN_SERVER_REPLY); return nullopt; }
+    if (k == std::string::npos) {
+      e.set(api::main(), errors::Subsystem::Main, errors::Main::UNKNOWN_SERVER_REPLY);
+      e.set_call(api::main(), errors::Call::BASIC_SKM_MAKE_LICENSE_KEY);
+      return nullopt;
+    }
 
     std::string version = s.substr(0, k);
     std::string rem = s.substr(k+1, std::string::npos);
     // NOTE: s.substr(s.size(), _) returns empty string, thus the previous line does never throw
 
     k = rem.find('-');
-    if (k == std::string::npos) { e.set(api::main(), errors::Subsystem::Main, errors::Main::UNKNOWN_SERVER_REPLY); return nullopt; }
+    if (k == std::string::npos) {
+      e.set(api::main(), errors::Subsystem::Main, errors::Main::UNKNOWN_SERVER_REPLY);
+      e.set_call(api::main(), errors::Call::BASIC_SKM_MAKE_LICENSE_KEY);
+      return nullopt;
+    }
 
     std::string license = rem.substr(0, k);
     std::string signature = rem.substr(k+1, std::string::npos); // k+1 is fine, see comment above

--- a/include/cryptolens/basic_SKM.hpp
+++ b/include/cryptolens/basic_SKM.hpp
@@ -409,17 +409,30 @@ basic_SKM<RequestHandler, SignatureVerifier>::make_license_key(basic_Error & e, 
     ::cryptolens_io::v20180502::internal::handle_activate(e, this->signature_verifier, s);
 
   if (e) {
+    if (e.get_subsystem(api::main()) != errors::Subsystem::Json) {
+      e.set_call(api::main(), errors::Call::BASIC_SKM_MAKE_LICENSE_KEY);
+      return nullopt;
+    }
+
     e.reset(api::main());
 
     size_t k = s.find('-');
-    if (k == std::string::npos) { e.set(api::main(), errors::Subsystem::Main, errors::Main::UNKNOWN_SERVER_REPLY); return nullopt; }
+    if (k == std::string::npos) {
+      e.set(api::main(), errors::Subsystem::Main, errors::Main::UNKNOWN_SERVER_REPLY);
+      e.set_call(api::main(), errors::Call::BASIC_SKM_MAKE_LICENSE_KEY);
+      return nullopt;
+    }
 
     std::string version = s.substr(0, k);
     std::string rem = s.substr(k+1, std::string::npos);
     // NOTE: s.substr(s.size(), _) returns empty string, thus the previous line does never throw
 
     k = rem.find('-');
-    if (k == std::string::npos) { e.set(api::main(), errors::Subsystem::Main, errors::Main::UNKNOWN_SERVER_REPLY); return nullopt; }
+    if (k == std::string::npos) {
+      e.set(api::main(), errors::Subsystem::Main, errors::Main::UNKNOWN_SERVER_REPLY);
+      e.set_call(api::main(), errors::Call::BASIC_SKM_MAKE_LICENSE_KEY);
+      return nullopt;
+    }
 
     std::string license = rem.substr(0, k);
     std::string signature = rem.substr(k+1, std::string::npos); // k+1 is fine, see comment above


### PR DESCRIPTION
Ensure errors from make_license_key include the failing API call. Add e.set_call(api::main(), errors::Call::BASIC_SKM_MAKE_LICENSE_KEY) in include/cryptolens/basic_Cryptolens.hpp and include/cryptolens/basic_SKM.hpp for non-JSON activation errors and when parsing the server reply (missing '-' separators) so error reports carry correct call context.