### PR TITLE
Fix issue when period or intvalue (data object) are negative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,5 +59,6 @@ target_include_directories (cryptolens PRIVATE "${cryptolens_SOURCE_DIR}/third_p
 target_include_directories (cryptolens PUBLIC "${cryptolens_SOURCE_DIR}/include")
 
 if (${CRYPTOLENS_BUILD_TESTS})
-  add_subdirectory (tests)
+  enable_testing ()
+  add_subdirectory (cmake/tests)
 endif ()

--- a/cmake/tests/CMakeLists.txt
+++ b/cmake/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable (
+  cryptolens_response_parser_tests
+  "ResponseParser_ArduinoJson7_tests.cpp"
+)
+
+target_link_libraries (cryptolens_response_parser_tests PRIVATE cryptolens)
+
+add_test (
+  NAME cryptolens_response_parser_tests
+  COMMAND cryptolens_response_parser_tests
+)

--- a/cmake/tests/ResponseParser_ArduinoJson7_tests.cpp
+++ b/cmake/tests/ResponseParser_ArduinoJson7_tests.cpp
@@ -1,0 +1,103 @@
+#include <iostream>
+#include <string>
+
+#include <cryptolens/Error.hpp>
+#include <cryptolens/ResponseParser_ArduinoJson7.hpp>
+
+namespace cryptolens = cryptolens_io::latest;
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, char const* message)
+{
+  if (!condition) {
+    std::cerr << message << std::endl;
+    ++failures;
+  }
+}
+
+std::string license_json(std::string const& f5_member)
+{
+  return std::string(
+      "{"
+      "\"ProductId\":1,"
+      "\"Created\":1,"
+      "\"Expires\":1,"
+      "\"Period\":-7,"
+      "\"Block\":false,"
+      "\"TrialActivation\":false,"
+      "\"SignDate\":1,"
+      "\"F1\":false,"
+      "\"F2\":false,"
+      "\"F3\":false,"
+      "\"F4\":false,")
+    + f5_member
+    + "\"F6\":false,"
+      "\"F7\":false,"
+      "\"F8\":false,"
+      "\"DataObjects\":[{"
+        "\"Id\":1,"
+        "\"Name\":\"quota\","
+        "\"StringValue\":\"\","
+        "\"IntValue\":-9"
+      "}]"
+      "}";
+}
+
+void signed_integer_values_are_preserved()
+{
+  cryptolens::Error error;
+  cryptolens::ResponseParser_ArduinoJson7 parser(error);
+  auto license = parser.make_license_key_information_unsafe(
+      error, license_json("\"F5\":true,"));
+
+  expect(!error, "A license with signed integer values should parse.");
+  expect(static_cast<bool>(license), "The parsed license should be present.");
+  if (!license) {
+    return;
+  }
+
+  expect(license->get_period() == -7, "The negative Period should be preserved.");
+  expect(license->get_f5(), "F5 should be parsed as true.");
+
+  auto const& data_objects = license->get_data_objects();
+  expect(static_cast<bool>(data_objects), "DataObjects should be present.");
+  if (!data_objects) {
+    return;
+  }
+
+  expect(data_objects->size() == 1, "Exactly one DataObject should be parsed.");
+  if (data_objects->size() == 1) {
+    expect(
+        data_objects->front().get_int_value() == -9,
+        "The negative DataObject IntValue should be preserved.");
+  }
+}
+
+void invalid_f5_is_rejected(std::string const& f5_member, char const* message)
+{
+  cryptolens::Error error;
+  cryptolens::ResponseParser_ArduinoJson7 parser(error);
+  auto license =
+      parser.make_license_key_information_unsafe(error, license_json(f5_member));
+
+  expect(static_cast<bool>(error), message);
+  expect(!license, "An invalid F5 value should not produce a license.");
+  expect(
+      error.get_subsystem() == cryptolens::errors::Subsystem::Json,
+      "An invalid F5 value should report the JSON subsystem.");
+}
+
+} // namespace
+
+int main()
+{
+  signed_integer_values_are_preserved();
+  invalid_f5_is_rejected("", "A missing F5 field should be rejected.");
+  invalid_f5_is_rejected(
+      "\"F5\":\"true\",", "A non-Boolean F5 field should be rejected.");
+
+  return failures == 0 ? 0 : 1;
+}

--- a/src/ResponseParser_ArduinoJson5.cpp
+++ b/src/ResponseParser_ArduinoJson5.cpp
@@ -45,7 +45,7 @@ ResponseParser_ArduinoJson5::make_license_key_information_unsafe(basic_Error & e
       !( j["ProductId"].is<unsigned long>()
       && j["Created"].is<unsigned long>()
       && j["Expires"].is<unsigned long>()
-      && j["Period"].is<unsigned long>()
+      && j["Period"].is<int>()
       && j["Block"].is<bool>()
       && j["TrialActivation"].is<bool>()
       && j["SignDate"].is<unsigned long>()
@@ -169,13 +169,13 @@ ResponseParser_ArduinoJson5::make_license_key_information_unsafe(basic_Error & e
       if (  dataobject["Id"].is<unsigned long>()
          && dataobject["Name"].is<const char*>() && dataobject["Name"].as<const char*>() != NULL
          && dataobject["StringValue"].is<const char*>() && dataobject["StringValue"].as<const char*>() != NULL
-         && dataobject["IntValue"].is<unsigned long>()
+         && dataobject["IntValue"].is<int>()
          )
       {
         v.emplace_back( dataobject["Id"].as<unsigned long>()
                       , dataobject["Name"].as<const char*>()
                       , dataobject["StringValue"].as<const char*>()
-                      , dataobject["IntValue"].as<unsigned long>()
+                      , dataobject["IntValue"].as<int>()
                       );
       } else {
         valid = false;
@@ -193,7 +193,7 @@ ResponseParser_ArduinoJson5::make_license_key_information_unsafe(basic_Error & e
     j["ProductId"].as<unsigned long>(),
     j["Created"].as<unsigned long>(),
     j["Expires"].as<unsigned long>(),
-    j["Period"].as<unsigned long>(),
+    j["Period"].as<int>(),
     j["Block"].as<bool>(),
     j["TrialActivation"].as<bool>(),
     j["SignDate"].as<unsigned long>(),

--- a/src/ResponseParser_ArduinoJson7.cpp
+++ b/src/ResponseParser_ArduinoJson7.cpp
@@ -46,7 +46,7 @@ ResponseParser_ArduinoJson7::make_license_key_information_unsafe(basic_Error & e
       !( j["ProductId"].is<unsigned long>()
       && j["Created"].is<unsigned long>()
       && j["Expires"].is<unsigned long>()
-      && j["Period"].is<unsigned long>()
+      && j["Period"].is<int>()
       && j["Block"].is<bool>()
       && j["TrialActivation"].is<bool>()
       && j["SignDate"].is<unsigned long>()
@@ -54,7 +54,7 @@ ResponseParser_ArduinoJson7::make_license_key_information_unsafe(basic_Error & e
       && j["F2"].is<bool>()
       && j["F3"].is<bool>()
       && j["F4"].is<bool>()
-      && j["F7"].is<bool>()
+      && j["F5"].is<bool>()
       && j["F6"].is<bool>()
       && j["F7"].is<bool>()
       && j["F8"].is<bool>()
@@ -161,13 +161,13 @@ ResponseParser_ArduinoJson7::make_license_key_information_unsafe(basic_Error & e
       if (  dataobject["Id"].is<unsigned long>()
          && dataobject["Name"].is<const char*>() && dataobject["Name"].as<const char*>() != NULL
          && dataobject["StringValue"].is<const char*>() && dataobject["StringValue"].as<const char*>() != NULL
-         && dataobject["IntValue"].is<unsigned long>()
+         && dataobject["IntValue"].is<int>()
          )
       {
         v.emplace_back( dataobject["Id"].as<unsigned long>()
                       , dataobject["Name"].as<const char*>()
                       , dataobject["StringValue"].as<const char*>()
-                      , dataobject["IntValue"].as<unsigned long>()
+                      , dataobject["IntValue"].as<int>()
                       );
       } else {
         valid = false;
@@ -185,7 +185,7 @@ ResponseParser_ArduinoJson7::make_license_key_information_unsafe(basic_Error & e
     j["ProductId"].as<unsigned long>(),
     j["Created"].as<unsigned long>(),
     j["Expires"].as<unsigned long>(),
-    j["Period"].as<unsigned long>(),
+    j["Period"].as<int>(),
     j["Block"].as<bool>(),
     j["TrialActivation"].as<bool>(),
     j["SignDate"].as<unsigned long>(),


### PR DESCRIPTION
Fixes #25

## Changelog

- Parse license `Period` as a signed integer in both ArduinoJson 5 and ArduinoJson 7 parsers, preserving negative values.
- Parse data-object `IntValue` as a signed integer in both parsers, preserving negative values.
- Validate the mandatory `F5` Boolean field in the ArduinoJson 7 parser instead of checking `F7` twice.
- Add dependency-free CTest regression coverage through `CRYPTOLENS_BUILD_TESTS`.
- Cover negative `Period`, negative data-object `IntValue`, and missing or non-Boolean `F5` responses.
- Preserve existing public types and APIs; only parsing and validation behavior changes.
